### PR TITLE
Fix/preserve initial segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# silence_remover
+
+`silence_remover.ps1` は、動画ファイルから無音部分を自動的に検出し、削除するスクリプトです。
+
+## 前提条件
+
+- Windows
+- FFmpeg がインストールされていること
+- PowerShell 実行環境
+
+## FFmpegのインストール方法
+
+- [FFmpeg公式サイト](https://ffmpeg.org/download.html)からFFmpegをダウンロード
+- ダウンロードしたzipファイルを解凍
+- 解凍したフォルダ内の`bin`フォルダを環境変数PATHに追加
+
+## 使用方法
+
+- 処理したい動画ファイルを`in.mp4`という名前でスクリプトと同じフォルダに配置
+- PowerShell起動
+- スクリプトのあるフォルダに移動
+- 以下のコマンドでスクリプトの実行を許可：
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
+```
+- スクリプトを実行：
+```powershell
+.\silence_remover.ps1
+```
+
+## 出力ファイル
+
+- `outall.mp4`: 無音部分が削除され、音声が正規化された最終出力ファイル
+- その他の中間ファイル：
+  - `spec.txt`: 無音検出結果
+  - `start.txt`, `end.txt`: 無音部分の開始・終了時間
+  - `out{n}.mp4`: 処理の中間ファイル
+
+## パラメータ設定
+
+スクリプト内の以下のパラメータを必要に応じて調整可能：
+
+- `$initial_db = -60`: 無音検出の初期しきい値(dB)
+- `$db_step = 5`: 無音検出の調整ステップ(dB)
+- `$max_attempts = 4`: 無音検出の最大試行回数
+- `d=0.4`: 無音と判定する最小の継続時間(秒)
+- `$bin_arr_length = 100`: 一度に処理する無音区間の数
+
+スクリプトは自動的に最適な無音検出しきい値を見つけようとします。初期値の-60dBから開始し、無音区間が見つからない場合は徐々にしきい値を上げていきます。

--- a/silence_remover.ps1
+++ b/silence_remover.ps1
@@ -1,49 +1,51 @@
 #detect silence
 ffmpeg -i "in.mp4" -af silencedetect=noise=-60dB:d=0.4 -f null - 2> spec.txt
-[regex]::Matches((Get-Content .\spec.txt),"silence_start: ([1-9]\d*|0)(\.\d+)?") | foreach{$_.Value}> start.txt
-[regex]::Matches((Get-Content .\spec.txt),"silence_end: ([1-9]\d*|0)(\.\d+)?") | foreach{$_.Value}> end.txt
-$start_time = [regex]::Matches((Get-Content .\start.txt),"([1-9]\d*|0)(\.\d+)?") | foreach{$_.Value}
-$end_time = [regex]::Matches((Get-Content .\end.txt),"([1-9]\d*|0)(\.\d+)?") | foreach{$_.Value}
+[regex]::Matches((Get-Content .\spec.txt), "silence_start: ([1-9]\d*|0)(\.\d+)?") | foreach { $_.Value }> start.txt
+[regex]::Matches((Get-Content .\spec.txt), "silence_end: ([1-9]\d*|0)(\.\d+)?") | foreach { $_.Value }> end.txt
+$start_time = [regex]::Matches((Get-Content .\start.txt), "([1-9]\d*|0)(\.\d+)?") | foreach { $_.Value }
+$end_time = [regex]::Matches((Get-Content .\end.txt), "([1-9]\d*|0)(\.\d+)?") | foreach { $_.Value }
 
 #process each $bin_arr_length streams
-$arr_length = $start_time.Length -1
-$bin_arr_length=100
-$trial_all = [Math]::Floor($arr_length/$bin_arr_length);
+$arr_length = $start_time.Length - 1
+$bin_arr_length = 100
+$trial_all = [Math]::Floor($arr_length / $bin_arr_length);
 
-$index_bin_end =@(0)
-if($trial_all -eq 0){
-$index_bin_end += $arr_length 
-}else{
-foreach($i in 1..$trial_all){$index_bin_end += $i*$bin_arr_length}
-if($index_bin_end[-1] -eq $arr_length){
-}else {
-$index_bin_end += $arr_length 
+$index_bin_end = @(0)
+if ($trial_all -eq 0) {
+    $index_bin_end += $arr_length 
 }
+else {
+    foreach ($i in 1..$trial_all) { $index_bin_end += $i * $bin_arr_length }
+    if ($index_bin_end[-1] -eq $arr_length) {
+    }
+    else {
+        $index_bin_end += $arr_length 
+    }
 }
 
 
 #generate outn.mp4 files
-$num_trial_repeat = $index_bin_end.Length-1
-foreach($j in 1..$num_trial_repeat){
+$num_trial_repeat = $index_bin_end.Length - 1
+foreach ($j in 1..$num_trial_repeat) {
 
-$ffmpeg_com = 'ffmpeg -i in.mp4 -filter_complex "'
-$index_process = ($index_bin_end[$j-1]+1)..($index_bin_end[$j])
+    $ffmpeg_com = 'ffmpeg -i in.mp4 -filter_complex "'
+    $index_process = ($index_bin_end[$j - 1] + 1)..($index_bin_end[$j])
 
-foreach ($i in $index_process){$ffmpeg_com=$ffmpeg_com+"[0:v]trim="+[string]([single]$end_time[$i-1]-0.001)+":"+[string]([single]$start_time[$i]+0.001)+",setpts=PTS-STARTPTS[v"+[string]($i-1)+"]; [0:a]atrim="+[string]([single]$end_time[$i-1]-0.001)+":"+[string]([single]$start_time[$i]+0.001)+",asetpts=PTS-STARTPTS[a"+[string]($i-1)+"]; "}
-foreach ($i in $index_process){$ffmpeg_com=$ffmpeg_com+"[v"+[string]($i-1)+"][a"+[string]($i-1)+"]"}
-$num_streams = $index_process.Length
-$ffmpeg_com = $ffmpeg_com +'concat=n='+[string]($num_streams)+':v=1:a=1[outv][outa]" -map "[outv]" -map "[outa]" out'+[string]$j+'.mp4'
+    foreach ($i in $index_process) { $ffmpeg_com = $ffmpeg_com + "[0:v]trim=" + [string]([single]$end_time[$i - 1] - 0.001) + ":" + [string]([single]$start_time[$i] + 0.001) + ",setpts=PTS-STARTPTS[v" + [string]($i - 1) + "]; [0:a]atrim=" + [string]([single]$end_time[$i - 1] - 0.001) + ":" + [string]([single]$start_time[$i] + 0.001) + ",asetpts=PTS-STARTPTS[a" + [string]($i - 1) + "]; " }
+    foreach ($i in $index_process) { $ffmpeg_com = $ffmpeg_com + "[v" + [string]($i - 1) + "][a" + [string]($i - 1) + "]" }
+    $num_streams = $index_process.Length
+    $ffmpeg_com = $ffmpeg_com + 'concat=n=' + [string]($num_streams) + ':v=1:a=1[outv][outa]" -map "[outv]" -map "[outa]" out' + [string]$j + '.mp4'
 
-$ffmpeg_com > com_ffmpeg.ps1
-.\com_ffmpeg.ps1
+    $ffmpeg_com > com_ffmpeg.ps1
+    .\com_ffmpeg.ps1
 }
 
 #generate out.mp4 files
 $ffmpeg_com_concat = 'ffmpeg '
-foreach($j in 1..$num_trial_repeat){$ffmpeg_com_concat = $ffmpeg_com_concat + "-i out$j.mp4 "}
+foreach ($j in 1..$num_trial_repeat) { $ffmpeg_com_concat = $ffmpeg_com_concat + "-i out$j.mp4 " }
 $ffmpeg_com_concat = $ffmpeg_com_concat + '-filter_complex "'
-foreach($j in 1..$num_trial_repeat){$ffmpeg_com_concat = $ffmpeg_com_concat + "["+[string]($j-1)+":v] ["+[string]($j-1)+":a] "}
-$ffmpeg_com_concat = $ffmpeg_com_concat + 'concat=n='+[string]($num_trial_repeat)+':v=1:a=1 [v] [a]" -map "[v]" -map "[a]" out.mp4'
+foreach ($j in 1..$num_trial_repeat) { $ffmpeg_com_concat = $ffmpeg_com_concat + "[" + [string]($j - 1) + ":v] [" + [string]($j - 1) + ":a] " }
+$ffmpeg_com_concat = $ffmpeg_com_concat + 'concat=n=' + [string]($num_trial_repeat) + ':v=1:a=1 [v] [a]" -map "[v]" -map "[a]" out.mp4'
 
 $ffmpeg_com_concat > com_ffmpeg_concat.ps1
 .\com_ffmpeg_concat.ps1

--- a/silence_remover.ps1
+++ b/silence_remover.ps1
@@ -31,7 +31,26 @@ foreach ($j in 1..$num_trial_repeat) {
     $ffmpeg_com = 'ffmpeg -i in.mp4 -filter_complex "'
     $index_process = ($index_bin_end[$j - 1] + 1)..($index_bin_end[$j])
 
-    foreach ($i in $index_process) { $ffmpeg_com = $ffmpeg_com + "[0:v]trim=" + [string]([single]$end_time[$i - 1] - 0.001) + ":" + [string]([single]$start_time[$i] + 0.001) + ",setpts=PTS-STARTPTS[v" + [string]($i - 1) + "]; [0:a]atrim=" + [string]([single]$end_time[$i - 1] - 0.001) + ":" + [string]([single]$start_time[$i] + 0.001) + ",asetpts=PTS-STARTPTS[a" + [string]($i - 1) + "]; " }
+    foreach ($i in $index_process) {
+        if ($i -eq ($index_bin_end[$j - 1] + 1)) {
+            if ($i -eq 1) {
+                $ffmpeg_com = $ffmpeg_com + "[0:v]trim=0:" + [string]([single]$start_time[0] + 0.001) + ",setpts=PTS-STARTPTS[v" + [string]($i - 1) + "]; " +
+                "[0:a]atrim=0:" + [string]([single]$start_time[0] + 0.001) + ",asetpts=PTS-STARTPTS[a" + [string]($i - 1) + "]; "
+            }
+            else {
+                $ffmpeg_com = $ffmpeg_com + "[0:v]trim=" + [string]([single]$end_time[$i - 2] - 0.001) + ":" + [string]([single]$start_time[$i - 1] + 0.001) + ",setpts=PTS-STARTPTS[v" + [string]($i - 1) + "]; " +
+                "[0:a]atrim=" + [string]([single]$end_time[$i - 2] - 0.001) + ":" + [string]([single]$start_time[$i - 1] + 0.001) + ",asetpts=PTS-STARTPTS[a" + [string]($i - 1) + "]; "
+            }
+        }
+        elseif ($i -eq $index_bin_end[$j]) {
+            $ffmpeg_com = $ffmpeg_com + "[0:v]trim=" + [string]([single]$end_time[$i - 1] - 0.001) + ",setpts=PTS-STARTPTS[v" + [string]($i - 1) + "]; " +
+            "[0:a]atrim=" + [string]([single]$end_time[$i - 1] - 0.001) + ",asetpts=PTS-STARTPTS[a" + [string]($i - 1) + "]; "
+        }
+        else {
+            $ffmpeg_com = $ffmpeg_com + "[0:v]trim=" + [string]([single]$end_time[$i - 2] - 0.001) + ":" + [string]([single]$start_time[$i - 1] + 0.001) + ",setpts=PTS-STARTPTS[v" + [string]($i - 1) + "]; " +
+            "[0:a]atrim=" + [string]([single]$end_time[$i - 2] - 0.001) + ":" + [string]([single]$start_time[$i - 1] + 0.001) + ",asetpts=PTS-STARTPTS[a" + [string]($i - 1) + "]; "
+        }
+    }
     foreach ($i in $index_process) { $ffmpeg_com = $ffmpeg_com + "[v" + [string]($i - 1) + "][a" + [string]($i - 1) + "]" }
     $num_streams = $index_process.Length
     $ffmpeg_com = $ffmpeg_com + 'concat=n=' + [string]($num_streams) + ':v=1:a=1[outv][outa]" -map "[outv]" -map "[outa]" out' + [string]$j + '.mp4'


### PR DESCRIPTION
## 概要
- Issue #1 の現象を改善しました。

## 詳細
- バグ修正
   - 動画の先頭から初回の無音区間までが意図せずカットされてしまう問題を修正
   - 動画の末尾から直前の無音区間までが意図せずカットされてしまう問題を修正

- 機能改善
   - 適切なdB値を自動的に検出するための簡易的な処理を実装

- コード整形
   - VSCodeの機能でフォーマット

- ドキュメント追加
   - README.mdを新規作成